### PR TITLE
Implementing a "Split-Screen" design where the user is able to browse…

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -20,6 +20,15 @@ def friend_data():
     return render_template("friend_data_view.html")
 
 
+@main.route("/events")
+def events_joined_available():
+    return render_template(
+        "event_joined_available.html")
+
+
+@main.route("/events/joined-available")
+def events_joined_available_alias():
+    return render_template("event_joined_available.html")
 
 
 

--- a/app/static/css/event_joined_available.css
+++ b/app/static/css/event_joined_available.css
@@ -1,0 +1,31 @@
+.event-section-card {
+    background-color: var(--background-nav);
+    border: 1px solid var(--green-border);
+    border-radius: 12px;
+}
+
+.available-event-item,
+.joined-event-item {
+    border: 1px solid var(--green-border);
+    border-radius: 10px;
+    background-color: rgba(255, 255, 255, 0.01);
+    padding: 12px;
+}
+
+.event-link {
+    color: var(--green-primary);
+    text-decoration: none;
+    border-bottom: 1px dashed transparent;
+    transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.event-link:hover {
+    color: #86efac;
+    border-color: #86efac;
+}
+
+@media (max-width: 991.98px) {
+    .split-events-layout > div {
+        width: 100%;
+    }
+}

--- a/app/templates/event_joined_available.html
+++ b/app/templates/event_joined_available.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% block content %}
+
+<link rel="stylesheet" href="{{ url_for('static', filename='css/event_joined_available.css') }}">
+
+<div class="split-header mb-4">
+	<p class="text-secondary small text-uppercase mb-1" style="letter-spacing: 0.1em;">Events</p>
+	<h2 class="fw-bold mb-0">Events Available & Events Joined</h2>
+	<p class="text-secondary mb-0 mt-2">
+	</p>
+</div>
+
+<div class="row g-4 split-events-layout">
+	<div class="col-lg-7">
+		<section class="event-section-card p-4 h-100">
+			<h4 class="fw-semibold mb-3">Events Available</h4>
+
+			{% for event in events_available %}
+			<article class="available-event-item {% if not loop.last %}mb-4{% endif %}">
+				<p class="mb-1"><strong>Event Name:</strong>
+					<a href="{{ event.external_url }}" target="_blank" rel="noopener noreferrer" class="event-link">{{ event.name }}</a>
+				</p>
+				<p class="mb-1"><strong>Location:</strong> {{ event.location }}</p>
+				<p class="mb-0"><strong>Description:</strong> {{ event.description }}</p>
+			</article>
+			{% else %}
+			<article class="available-event-item">
+				<p class="mb-1"><strong>Event Name:</strong> </p>
+				<p class="mb-1"><strong>Location:</strong> </p>
+				<p class="mb-0"><strong>Description:</strong> </p>
+			</article>
+			{% endfor %}
+		</section>
+	</div>
+
+	<div class="col-lg-5">
+		<section class="event-section-card p-4 h-100">
+			<h4 class="fw-semibold mb-3">Events Joined</h4>
+
+			{% for event in events_joined %}
+			<article class="joined-event-item {% if not loop.last %}mb-2{% endif %}">
+				<p class="mb-0"><strong>Event Name:</strong> {{ event.name }}</p>
+			</article>
+			{% else %}
+			<article class="joined-event-item">
+				<p class="mb-0"><strong>Event Name:</strong> </p>
+			</article>
+			{% endfor %}
+		</section>
+	</div>
+</div>
+
+
+
+
+
+
+{% endblock %}


### PR DESCRIPTION
Hello team!

I have implement a skeleton design of the events joined and available

<img width="1460" height="718" alt="image" src="https://github.com/user-attachments/assets/1092d059-ca02-4135-b555-777301650687" />



Should there be any changes to colour/font of the page, do let me know :)

The current descriptions are missing as the data is meant from GET requests which we will implement on a later date.