### PR TITLE
Frontend responsiveness Fix

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -36,7 +36,7 @@
 </nav>
 
 <!--CONTENTS -->
-<div class="container mt-4">
+<div class="container px-3 px-md-4 mt-4">
     {% block content %}{% endblock %}
 </div>
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,10 +16,14 @@
 <body>
 
 <!-- NAVIGATIONBAR -->
-<nav class="navbar navbar-expand-lg px-4">
+<nav class="navbar navbar-expand-lg navbar-light px-4">
     <a class="navbar-brand" href="/">MatchUp</a>
 
-    <div class="ms-auto"> 
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+        <div class="ms-auto d-flex flex-wrap">
         <a class="nav-link d-inline" href="/matching">Match</a>
         <a class="nav-link d-inline" href="/events">Events</a>
         <a class="nav-link d-inline" href="/friends">Friends</a>
@@ -27,6 +31,7 @@
         {% if current_user.is_authenticated %}
         <a class="nav-link d-inline text-danger" href="{{ url_for('main.logout') }}">Log Out</a>
         {% endif %}
+        </div>
     </div>
 </nav>
 

--- a/app/templates/event_edit.html
+++ b/app/templates/event_edit.html
@@ -22,7 +22,7 @@
                     value="{{ event.event_name }}">
  
                 <div class="row g-3 mb-2">
-                    <div class="col">
+                    <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Sport</label>
                         <select class="form-select bg-dark border-success text-success" name="sport">
                             <option disabled>Choose</option>
@@ -37,7 +37,7 @@
                             <option {% if event.sport == 'Golf' %}selected{% endif %}>Golf</option>
                         </select>
                     </div>
-                    <div class="col">
+                    <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Spots</label>
                         <input
                             class="form-control text-success bg-dark border-success"
@@ -49,7 +49,7 @@
                 </div>
  
                 <div class="row g-3 mb-2">
-                    <div class="col">
+                    <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Date</label>
                         <input
                             class="form-control text-success bg-dark border-success"
@@ -57,7 +57,7 @@
                             name="date"
                             value="{{ event.date }}">
                     </div>
-                    <div class="col">
+                    <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Time</label>
                         <input
                             class="form-control text-success bg-dark border-success"

--- a/app/templates/event_joined_available.html
+++ b/app/templates/event_joined_available.html
@@ -11,7 +11,7 @@
 </div>
 
 <div class="row g-4 split-events-layout">
-	<div class="col-lg-7">
+	<div class="col-12 col-lg-7">
 		<section class="event-section-card p-4 h-100">
 			<h4 class="mb-3">Events Available</h4>
 
@@ -26,7 +26,7 @@
 		</section>
 	</div>
 
-	<div class="col-lg-5">
+	<div class="col-12 col-lg-5">
 		<section class="event-section-card p-4 h-100">
 			<h4 class="mb-3">Events Joined</h4>
 

--- a/app/templates/event_view.html
+++ b/app/templates/event_view.html
@@ -24,7 +24,7 @@
 <div class="row g-4">
 
     <!-- LEFT:Main info -->
-    <div class="col-lg-8 d-flex flex-column gap-4">
+    <div class="col-12 col-lg-8 d-flex flex-column gap-4">
 
         <!-- Header deatails card -->
         <div class="event-card p-4">
@@ -94,7 +94,7 @@
     </div>
 
     <!-- RIGHT: Spots progression -->
-    <div class="col-lg-4">
+    <div class="col-12 col-lg-4">
         <div class="event-card p-4">
             <div class="d-flex justify-content-between mb-2">
                 <span class="text-secondary small">Spots filled</span>

--- a/app/templates/homepage.html
+++ b/app/templates/homepage.html
@@ -68,11 +68,11 @@
 
             <form id="formsu" method="POST" action="{{ url_for('main.signup') }}">
                 <div class="row g-3 mb-2">
-                    <div class="col">
+                    <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">First name</label>
                         <input class="form-control text-success bg-dark border-success" name="first_name" placeholder="pibble" required>
                     </div>
-                    <div class="col">
+                    <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Last name</label>
                         <input class="form-control text-success bg-dark border-success" name="last_name" placeholder="Thedestroyer" required>
                     </div>
@@ -108,7 +108,7 @@
                 <label class="form-label text-secondary small">Event name</label>
                 <input class="form-control text-success bg-dark border-success mb-3" name="event_name" placeholder="e.g. Tennis at UWA" required>
                 <div class="row g-3 mb-2">
-                    <div class="col">
+                    <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Sport</label>
                         <select class="form-select bg-dark border-success text-success" name="sport" required>
                             <option disabled selected>Choose</option>
@@ -123,17 +123,17 @@
                             <option>Golf</option>
                         </select>
                     </div>
-                    <div class="col">
+                    <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Spots</label>
                         <input class="form-control text-success bg-dark border-success" name="spots_total" type="number" min="1" placeholder="10" required>
                     </div>
                 </div>
                 <div class="row g-3 mb-2">
-                    <div class="col">
+                    <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Date</label>
                         <input class="form-control text-success bg-dark border-success" name="date" type="date" required>
                     </div>
-                    <div class="col">
+                    <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Time</label>
                         <input class="form-control text-success bg-dark border-success" name="time" type="time" required>
                     </div>

--- a/app/templates/homepage.html
+++ b/app/templates/homepage.html
@@ -41,14 +41,14 @@
     </div>
 </div>
 
-<div class="d-flex align-items-center justify-content-between gap-4 py-5">
-    <div class="flex-fill">
+<div class="d-flex flex-column flex-md-row align-items-center justify-content-between gap-4 py-5">
+    <div class="flex-fill w-100">
         <p class="text-secondary small text-uppercase mb-3">— GET STARTED</p>
         <h1>READY TO <span class="text-success">PLAY?</span></h1>
         <p>Connect with players and <span class="text-success">IMPROVE</span> together!</p>
     </div>
     
-    <div class="flex-fill">
+    <div class="flex-fill w-100">
 
         {% if not current_user.is_authenticated %}
         <div class="card border-success p-4" id="auth-box" style="max-width: 480px; background: var(--background-nav);">

--- a/app/templates/homepage.html
+++ b/app/templates/homepage.html
@@ -51,7 +51,7 @@
     <div class="flex-fill w-100">
 
         {% if not current_user.is_authenticated %}
-        <div class="card border-success p-4" id="auth-box" style="max-width: 480px; background: var(--background-nav);">
+        <div class="card border-success p-4 w-100" id="auth-box" style="max-width: 480px; background: var(--background-nav);">
             <h2>Join MatchUp</h2>
             <p>Sign up or log in to start matching.</p>
 
@@ -94,7 +94,7 @@
         </div>
 
         {% else %}
-        <div class="card border-success p-4" id="create-box" style="max-width: 480px; background: var(--background-nav);">
+        <div class="card border-success p-4 w-100" id="create-box" style="max-width: 480px; background: var(--background-nav);">
             <h2>Create an event!</h2>
             <p id="welcome">What are you playing, {{ current_user.first_name }}?</p>
 


### PR DESCRIPTION
<img width="503" height="883" alt="Screenshot 2026-05-10 171633" src="https://github.com/user-attachments/assets/947601e2-2c4c-4cf2-94ab-d87a6ee0912d" />
I have fixed responsiveness across all pages, an example is the front page on small screens instead of having first name and last name side by side , they get stacked vertically so that it is easier to navigate on smaller screens, and the "ready to play message" goes on top instead of besides the box. Also wherever there were 2 sections side by side these were also vertically stacked as they might break on small screens. I tested them by minimising my tab as show in the screenshot, further tests will be done later on but everything should be good to go. This fixes #26 .