### PR TITLE
Spots and remove friend fix

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -478,7 +478,23 @@ def event_view(event_id):
         user_id=current_user.user_id
     ).first() is not None
 
-    return render_template("event_view.html", event=event, user_has_joined=user_has_joined)
+    friends = Friends.query.filter_by(user_id=current_user.user_id).all()
+    friend_ids = {f.friend_id for f in friends}
+
+    host_attendee = None
+    friend_attendees = []
+    for a in event.members:
+        if a.is_host:
+            host_attendee = a
+        elif a.user_id in friend_ids:
+            friend_attendees.append(a)
+
+    visible_attendees = []
+    if host_attendee:
+        visible_attendees.append(host_attendee)
+    visible_attendees += friend_attendees[:4]  
+
+    return render_template("event_view.html", event=event, user_has_joined=user_has_joined, friend_ids=friend_ids, visible_attendees=visible_attendees)
 
 @main.route("/events/<int:event_id>/join")
 @login_required

--- a/app/routes.py
+++ b/app/routes.py
@@ -423,22 +423,28 @@ def create_event():
     if not all([event_name, sport, location, postcode_raw, date_str, time_str, spots_total]):
         flash("All fields except description are required.", "danger")
         return redirect(url_for("main.homepage"))
-
     try:
         date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
         time = datetime.datetime.strptime(time_str, "%H:%M").time()
-        spots_total = int(spots_total)
-        if spots_total < 1:
-            raise ValueError
+        
     except ValueError:
-        flash("Invalid date, time, or spots value.", "danger")
+        flash("Invalid date or time", "danger")
         return redirect(url_for("main.homepage"))
     
     postcode, postcode_error = parse_postcode(postcode_raw, required=True)
     if postcode_error:
         flash(postcode_error, "danger")
         return redirect(url_for("main.homepage"))
+    
+    try:
+        spots_total = int(spots_total)
+    except ValueError:
+        flash("Spots must be a valid number.", "danger")
+        return redirect(url_for("main.homepage"))
 
+    if spots_total < 1 or spots_total > 360:
+        flash("Spots must be between 1 and 360.", "danger")
+        return redirect(url_for("main.homepage"))
     event = Events(
         owner_id    = current_user.user_id,
         event_name  = event_name,
@@ -577,23 +583,32 @@ def event_edit(event_id):
             return redirect(url_for("main.event_edit", event_id=event_id))
 
         try:
+            spots_total = int(spots_total)
+        except ValueError:
+            flash("Spots must be a valid number.", "danger")
+            return redirect(url_for("main.event_edit", event_id=event_id))
+
+        if spots_total < 1 or spots_total > 360:
+            flash("Spots must be between 1 and 360.", "danger")
+            return redirect(url_for("main.event_edit", event_id=event_id))
+        
+        try:
             event.date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
             try:
                 event.time = datetime.datetime.strptime(time_str, "%H:%M").time()
             except ValueError:
                 event.time = datetime.datetime.strptime(time_str, "%H:%M:%S").time()
-            event.spots_total = int(spots_total)
-            if event.spots_total < 1:
-                raise ValueError
         except ValueError:
-            flash("Invalid date, time, or spots value.", "danger")
+            flash("Invalid date or time value.", "danger")
             return redirect(url_for("main.event_edit", event_id=event_id))
+        
         
         event.event_name  = event_name
         event.sport       = sport
         event.location    = location
         event.postcode    = postcode
         event.description = description
+        event.spots_total = spots_total
 
         db.session.commit()
         flash("Event updated successfully.", "success")

--- a/app/routes.py
+++ b/app/routes.py
@@ -442,8 +442,8 @@ def create_event():
         flash("Spots must be a valid number.", "danger")
         return redirect(url_for("main.homepage"))
 
-    if spots_total < 1 or spots_total > 360:
-        flash("Spots must be between 1 and 360.", "danger")
+    if spots_total < 2 or spots_total > 360:
+        flash("Spots must be between 2 and 360.", "danger")
         return redirect(url_for("main.homepage"))
     event = Events(
         owner_id    = current_user.user_id,
@@ -588,8 +588,8 @@ def event_edit(event_id):
             flash("Spots must be a valid number.", "danger")
             return redirect(url_for("main.event_edit", event_id=event_id))
 
-        if spots_total < 1 or spots_total > 360:
-            flash("Spots must be between 1 and 360.", "danger")
+        if spots_total < 2 or spots_total > 360:
+            flash("Spots must be between 2 and 360.", "danger")
             return redirect(url_for("main.event_edit", event_id=event_id))
         
         try:

--- a/app/static/js/friends_data_view.js
+++ b/app/static/js/friends_data_view.js
@@ -4,19 +4,22 @@ document.getElementById('removeFriendBtn').addEventListener('click', function() 
     const csrfTokenMeta = document.querySelector('meta[name="csrf-token"]');
     const csrfToken = csrfTokenMeta ? csrfTokenMeta.getAttribute('content') : null;
     
-    if (confirm('Are you sure you want to remove this friend?')) {
+     this.disabled = true;
 
-        this.disabled = true;
-
-        fetch(`/friends/${friendId}/remove`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': csrfToken || ''
-            }
-        })
-        .then(() => {
+    fetch(`/friends/${friendId}/remove`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': csrfToken || ''
+        }
+    })
+    .then(res => res.json())
+    .then(data => {
+        if (data.ok) {
             window.location.href = redirectUrl;
-        });
-    }
+        } else {
+            alert(data.message);
+            this.disabled = false;
+        }
+    });
 });

--- a/app/templates/event_edit.html
+++ b/app/templates/event_edit.html
@@ -50,6 +50,7 @@
                             type="number"
                             name="spots_total"
                             min="1"
+                            max="360"
                             value="{{ event.spots_total }}">
                     </div>
                 </div>

--- a/app/templates/event_edit.html
+++ b/app/templates/event_edit.html
@@ -49,7 +49,7 @@
                             class="form-control text-success bg-dark border-success"
                             type="number"
                             name="spots_total"
-                            min="1"
+                            min="2"
                             max="360"
                             value="{{ event.spots_total }}">
                     </div>

--- a/app/templates/event_view.html
+++ b/app/templates/event_view.html
@@ -70,9 +70,9 @@
             </h5>
             <div class="d-flex flex-wrap gap-3 align-items-center">
 
-                {% for attendee in event.members %}
+                {% for attendee in visible_attendees %}
                 <div class="d-flex align-items-center gap-2">
-                    <div class=>{{ attendee.user.first_name[0] }}</div>
+                    <div class="rounded-circle bg-success text-dark d-flex align-items-center justify-content-center fw-bold" style="width:36px; height:36px;">{{ attendee.user.first_name[0] }}</div>
                     <span class="small">{{ attendee.user.first_name }} {{ attendee.user.last_name }}</span>
                     {% if attendee.is_host %}
                         <span class="badge text-success border border-success bg-transparent rounded-pill small">Host</span>
@@ -80,12 +80,9 @@
                 </div>
                 {% endfor %}
 
-                {% for i in range(event.spots_total - event.spots_filled) %}
-                <div class="d-flex align-items-center gap-2">
-                    <div class=" bg-transparent border border-secondary text-secondary" style="border-style: dashed !important;">+</div>
-                    <span class="small text-secondary">Open spot</span>
-                </div>
-                {% endfor %}
+                {% if visible_attendees|length <= 1 %}
+                    <p class="text-secondary small mb-0 mt-2">No friends have joined yet.</p>
+                {% endif %}
 
             </div>
         </div>

--- a/app/templates/friend_data_view.html
+++ b/app/templates/friend_data_view.html
@@ -39,7 +39,7 @@
                 </div>
                 <div class="col-12 col-md-6">
                     <label class="form-label text-secondary small d-block">Location (Postcode)</label>
-                    <p class="fs-5 text-success">{{ friend.postcode }}</p>
+                    <p class="fs-5 text-success">{{ '%04d' % friend.postcode if friend.postcode else 'Not set' }}</p>
                 </div>
                 <div class="col-12 col-md-6">
                     <label class="form-label text-secondary small d-block">Gender</label>
@@ -65,10 +65,9 @@
             <div class="mt-5 row g-2">
                 <div class="col-12">
                     <button type="button" 
-                            id="removeFriendBtn" 
-                            data-friend-id="{{ friend.user_id }}"
-                            data-friend-url="{{ url_for('main.friends_list') }}" 
-                            class="btn btn-outline-danger w-100 fw-semibold">
+                            class="btn btn-outline-danger w-100 fw-semibold"
+                            data-bs-toggle="modal"
+                            data-bs-target="#removeFriendModal">
                         Remove Friend
                     </button>
                 </div>
@@ -77,5 +76,30 @@
         </div>
     </div>
 </div>
+
+<div class="modal fade" id="removeFriendModal" tabindex="-1" aria-labelledby="removeFriendModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content bg-dark border-danger">
+            <div class="modal-header border-danger">
+                <h5 class="modal-title" id="removeFriendModalLabel">Remove Friend</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body text-secondary">
+                Are you sure you want to remove <span class="text-white fw-semibold">{{ friend.first_name }} {{ friend.last_name }}</span> as a friend? This cannot be undone.
+            </div>
+            <div class="modal-footer border-danger">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" 
+                        id="removeFriendBtn" 
+                        data-friend-id="{{ friend.user_id }}"
+                        data-friend-url="{{ url_for('main.friends_list') }}"
+                        class="btn btn-danger fw-semibold">
+                    Yes, remove them
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script src="{{ url_for('static', filename='js/friends_data_view.js') }}"></script>
 {% endblock %}

--- a/app/templates/homepage.html
+++ b/app/templates/homepage.html
@@ -88,9 +88,9 @@
             <form id="formli" class="d-none" method="POST" action="{{ url_for('main.login') }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <label class="form-label text-secondary small">Email</label>
-                <input class="form-control text-success bg-dark border-success mb-3" type="email" name="email" placeholder="youz@email.com" required>
+                <input class="form-control text-success bg-dark border-success mb-3" type="email" name="email" placeholder="pibblethedestroyer@gmail.com" required>
                 <label class="form-label text-secondary small">Password</label>
-                <input class="form-control text-success bg-dark border-success mb-3" type="password" name="password" placeholder="Youz password" required>
+                <input class="form-control text-success bg-dark border-success mb-3" type="password" name="password" placeholder="8+ characters" required>
                 <div class="form-check mb-3">
                     <input class="form-check-input" type="checkbox" name="remember_me" id="remember_me">
                     <label class="form-check-label text-secondary small" for="remember_me">Remember me</label>

--- a/app/templates/homepage.html
+++ b/app/templates/homepage.html
@@ -132,7 +132,7 @@
                     </div>
                     <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Spots</label>
-                        <input class="form-control text-success bg-dark border-success" name="spots_total" type="number" min="1" placeholder="10" required>
+                        <input class="form-control text-success bg-dark border-success" name="spots_total" type="number" min="1" max="360" placeholder="10" required>
                     </div>
                 </div>
                 <div class="row g-3 mb-2">

--- a/app/templates/homepage.html
+++ b/app/templates/homepage.html
@@ -132,7 +132,7 @@
                     </div>
                     <div class="col-12 col-sm-6">
                         <label class="form-label text-secondary small">Spots</label>
-                        <input class="form-control text-success bg-dark border-success" name="spots_total" type="number" min="1" max="360" placeholder="10" required>
+                        <input class="form-control text-success bg-dark border-success" name="spots_total" type="number" min="2" max="360" placeholder="10" required>
                     </div>
                 </div>
                 <div class="row g-3 mb-2">


### PR DESCRIPTION
<img width="507" height="322" alt="Screenshot 2026-05-12 175939" src="https://github.com/user-attachments/assets/f5e8ee60-dd49-4080-a3f8-9bc78c087186" />
<img width="1006" height="1107" alt="Screenshot 2026-05-12 175844" src="https://github.com/user-attachments/assets/aa1de127-a991-493a-b363-e12807fb02bc" />
<img width="1043" height="1748" alt="Screenshot 2026-05-12 173915" src="https://github.com/user-attachments/assets/a49c31aa-ee2a-45af-844c-4d99246550d3" />
<img width="1048" height="697" alt="Screenshot 2026-05-12 173858" src="https://github.com/user-attachments/assets/d332722d-06a8-4c6d-b956-be8e29fb21ac" />
I added a modal confirmation pop up for removing friends to match the delete event confirmation. I also changed the login placeholder to match signup and limited the number of spots to 360 spots(afl = 22 per team 22*16 for a tournament = 352, rounded up = 360). I also changed the spots available icon  on events view to show only the host and any five friend that have joined the event, if not it on shows host and say no friends joined. This fixes #61 